### PR TITLE
rjb was missing

### DIFF
--- a/lib/pdf/merger.rb
+++ b/lib/pdf/merger.rb
@@ -13,9 +13,9 @@ module PDF
     VERSION = "0.3.2"
 
     if RUBY_PLATFORM =~ /java/ # ifdef to check if your using JRuby
-      require 'pdf/merger/jruby'
+      require_relative "./merger/jruby.rb"
     else
-      require 'pdf/merger/rjb'
+      require_relative "./merger/rjb.rb"
     end
     # PDF::Merger provides an interface into iText allowing for the
     # merging of PDFs.

--- a/pdf-merger.gemspec
+++ b/pdf-merger.gemspec
@@ -56,6 +56,7 @@ Gem::Specification.new do |s|
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, [">= 0"])
     s.add_dependency(%q<jeweler>, [">= 0"])
+    s.add_dependency("rjb" "~>1.4.9")
   end
 end
 


### PR DESCRIPTION
I use `bundle install --binstubs --path vendor` to install, it sandboxes a project. I was getting lots of "LoadError: cannot load such file -- rjb" errors, because I don't have it installed system wide and the bundler install didn't know it was a dependency. I've added it to the gemspec.

Hope that helps.
iain 
